### PR TITLE
Fix Issue #2

### DIFF
--- a/app/(tabs)/monthlyEntries.js
+++ b/app/(tabs)/monthlyEntries.js
@@ -21,7 +21,7 @@ const MonthlyEntries = () => {
 
   const [month, setMonth] = useState(new Date().getMonth() + 1);
   const [monthString, setMonthString] = useState(
-    month < 9 ? `0${month}` : String(month)
+    month < 10 ? `0${month}` : String(month)
   );
   const [year, setYear] = useState(new Date().getFullYear());
   const [yearList, setYearList] = useState([]);


### PR DESCRIPTION
**Cause of Issue:** 0 was being appended only to digits **less than 9**.
```js
const [monthString, setMonthString] = useState(
    month < 9 ? `0${month}` : String(month)
);
```

**Fix:** 0 is now being appened to digits **less than 10**
```js
const [monthString, setMonthString] = useState(
    month < 10 ? `0${month}` : String(month)
);
```